### PR TITLE
Support extending js-yaml Schemas in getSchema().

### DIFF
--- a/src/get-schema.ts
+++ b/src/get-schema.ts
@@ -5,7 +5,11 @@ import namify from 'namify';
 import { IOpts } from './types';
 import read from './read';
 
-export default function getSchema(dir: string, options: IOpts = {}) {
+export default function getSchema(
+  dir: string,
+  options: IOpts = {},
+  schemas: yaml.Schema[] = [yaml.DEFAULT_SAFE_SCHEMA]
+) {
   if (!options.hasOwnProperty('ext') || !Array.isArray(options.ext)) {
     options.ext = ['.yml', '.yaml'];
   }
@@ -110,6 +114,6 @@ export default function getSchema(dir: string, options: IOpts = {}) {
       }
     })
   ];
-  const schema = yaml.Schema.create(types);
+  const schema = yaml.Schema.create(schemas, types);
   return schema;
 }


### PR DESCRIPTION
This adds an argument to the `getSchema()` function to allow passing in a list of existing js-yaml Schema objects to produce an extended schema from.

The actual logic doing this is handled entirely by js-yaml itself, it's Schema.create() function has a two-argument variant that takes a list of Schema objects as the first argument and a list of Type objects as the second argument, and produces a schema consisting of the existing types defined in the Schema objects passed in plus the list of Type objects passed in.

By default, this uses the `DEFAULT_SAFE_SCHEMA` from js-yaml as the Schema to extend, which produces behavior identical to calling `Schema.create()` with just a list of extension types.

By adding this functionality, yaml-import can be used with custom types, or with the special types provided by js-yaml for Javascript regular expressions and functions.

----

This came about because I'm working on a project that needs custom YAML types, but also significantly benefits from using yaml-import to keep file sizes manageable.

While I'm pretty sure I've got the correct type annotation here (the tests don't complain and it appears to work like it's supposed to both with and without the extra argument being passed), it would be nice to confirm that since this is literally the first time I've ever done anything with TypeScript.